### PR TITLE
Potential fixes for 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Arrays;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
 import org.owasp.webgoat.container.assignments.AttackResult;
@@ -45,8 +47,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
     return furBall(url);
   }
 
+  private static final List<String> AUTHORIZED_URLS = List.of("http://ifconfig.pro");
+  
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    if (AUTHORIZED_URLS.contains(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fixes for 3 code scanning alerts from the [Critical CodeQL alert1](https://github.com/orgs/ghas-bootcamp-2025-03-12-cloudlabs075/security/campaigns/3) security campaign:
- https://github.com/ghas-bootcamp-2025-03-12-cloudlabs075/ghas-bootcamp-WebGoat1/security/code-scanning/56
To fix the SSRF vulnerability, we should avoid using user-provided input directly in the URL creation. Instead, we can maintain a list of authorized URLs and validate the user input against this list. If the input matches an authorized URL, we proceed with the request; otherwise, we return a failure result.

  1. Create a list of authorized URLs.
  2. Validate the user-provided input against this list.
  3. Only proceed with the request if the input matches an authorized URL.
  


- https://github.com/ghas-bootcamp-2025-03-12-cloudlabs075/ghas-bootcamp-WebGoat1/security/code-scanning/55



- https://github.com/ghas-bootcamp-2025-03-12-cloudlabs075/ghas-bootcamp-WebGoat1/security/code-scanning/10
To fix the problem, we need to ensure that the XML parser is always configured to disable external entity parsing, regardless of the `webSession.isSecurityEnabled()` condition. This can be achieved by setting the necessary properties on the `XMLInputFactory` unconditionally.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
